### PR TITLE
DEVOPS-354: Use v1 of Firely Azure templates

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -7,7 +7,9 @@ resources:
     - repository: templates
       type: github
       name: FirelyTeam/azure-pipeline-templates
-      endpoint: FirelyTeam 
+      endpoint: FirelyTeam
+      ref: refs/tags/v1
+      
 
 variables:
   buildConfiguration: 'Release'

--- a/build/azure-release-pipeline.yml
+++ b/build/azure-release-pipeline.yml
@@ -7,7 +7,8 @@ resources:
     - repository: templates
       type: github
       name: FirelyTeam/azure-pipeline-templates
-      endpoint: FirelyTeam 
+      endpoint: FirelyTeam
+      ref: refs/tags/v1
 
 variables:
   buildConfiguration: 'Release'


### PR DESCRIPTION
Use version `v1` (base version) of the Firely Azure templates (FirelyTeam/azure-pipeline-templates).