### PR TITLE
chore: group minor and patch dependabot updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     time: "04:00"
   open-pull-requests-limit: 10
   target-branch: develop
+  groups:
+    minor-and-patch:
+      update-types:
+        - "minor"
+        - "patch"
   ignore:
   - dependency-name: Hl7.Fhir.Specification.STU3
     versions:


### PR DESCRIPTION
Groups all minor and patch dependency updates into a single weekly PR, reducing noise. Major updates will still get their own individual PRs.